### PR TITLE
chore: enhance Docker image tags to include stable version line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,8 @@ jobs:
       - name: Set tags
         id: tags
         run: |
-          tags="esacteksab/go:${{ matrix.go-version }}\nesacteksab/go:${{ matrix.go-version }}-${{ steps.date.outputs.date }}"
+          stable_line=$(echo "${{ matrix.go-version }}" | cut -d. -f1,2)
+          tags="esacteksab/go:${{ matrix.go-version }}\nesacteksab/go:${stable_line}\nesacteksab/go:${{ matrix.go-version }}-${{ steps.date.outputs.date }}"
           if [ "${{ matrix.go-version }}" = "${{ needs.get-versions.outputs.latest }}" ]; then
             tags="${tags}\nesacteksab/go:latest"
           fi


### PR DESCRIPTION
## Summary

- In an attempt to keep repos at their respective Go version rather than 1.25 -> 1.26.

## Release Notes Checklist

- [x] I applied at least one release label that matches `.github/release.yml`.
- [ ] If this PR should be excluded from release notes, I applied `ignore-changelog`.
- [ ] If this is a breaking change, I applied `type: breaking` and documented impact/migration notes.
